### PR TITLE
fix: gulp init

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,6 +84,8 @@ function npmInstall() {
     .on('error', reject)
     .pipe(gulp.src("./package.json"))
     .on('end', resolve);
+
+    resolve();
   })
 }
 gulp.task('npmInstall', npmInstall);


### PR DESCRIPTION
- `gulp init`에서 `npmInstall()` 함수에서 비동기 작업이 끝나지 않았다고 계속해서 에러 발생
- 강제로 작업완료 코드를 넣어야 완료 가능

아래 에러 내역은 계속해서 발생하는 에러 문구

```
The following tasks did not complete: npmInstall
Did you forget to signal async completion?
```

이 과정으로 `gulp init` 가 정상적으로 끝난다면 이후 오픈 플랫폼 서비스들이 연동되며 회원가입 및 로그인 또한 정상 작동함.

# OS 및 라이브러리 버전
- Linux version 4.18.0-553.32.1.el8_10.x86_64 (mockbuild@iad1-prod-build001.bld.equ.rockylinux.org) (gcc version 8.5.0 20210514 (Red Hat 8.5.0-22)
- gulp
  - CLI version: 2.2.0
  - Local version: 4.0.2
- Npm : 8.19.4
- Node : 16.20.2
- MongoDB : 4.2.3
